### PR TITLE
Updating url for coffeescript cookbook

### DIFF
--- a/issues.json
+++ b/issues.json
@@ -245,10 +245,10 @@
     {
         "title": "CoffeeScript Cookbook",
         "author": "Multiple Owner",
-        "authorUrl": "http://coffeescriptcookbook.com/authors",
+        "authorUrl": "https://coffeescript-cookbook.github.io/authors",
         "level": "Beginner",
         "info": "CoffeeScript recipes for the community by the community.",
-        "url": "http://coffeescriptcookbook.com/",
+        "url": "https://coffeescript-cookbook.github.io/",
         "cover": "img/cover_coffeescriptcookbook.png"
     },
     {


### PR DESCRIPTION
It appears that they've moved to a sub domain off github.io.