### PR TITLE
update javascript allonge link

### DIFF
--- a/issues.json
+++ b/issues.json
@@ -434,7 +434,7 @@
     "authorUrl": "http://braythwayt.com/",
     "level": "Intermediate",
     "info": "JavaScript Allongé is a book about programming with functions, because JavaScript is a programming language built on flexible and powerful functions.",
-    "url": "https://leanpub.com/javascript-allonge/read",
+    "url": "https://leanpub.com/javascriptallongesix/read",
     "cover": "img/JavaScriptAllonge.jpg",
     "tags": [
       "core"


### PR DESCRIPTION
I noticed that the current JavaScript Allongé link takes you to a "Book not published" page. It looks like it's been moved to https://leanpub.com/javascriptallongesix/read.