### PR TITLE
substack.net has no SSL support

### DIFF
--- a/issues.json
+++ b/issues.json
@@ -363,7 +363,7 @@
   }, {
     "title": "Stream handbook",
     "author": "James Halliday (substack)",
-    "authorUrl": "https://substack.net",
+    "authorUrl": "http://substack.net",
     "level": "Advanced",
     "info": "a free short e-book that teaches you how to write node programs with streams, by James Halliday a famous NodeJS supporter that published numerous awesome NodeJS modules",
     "url": "https://github.com/substack/stream-handbook",


### PR DESCRIPTION
The current link ( https://substack.net/ ) errors.