### PR TITLE
docs: Fix simple typo, langage -> language

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 JSbooks is a showcase of the bests free ebooks about Javascript.
 
-Find here the best publications about your favourite programming langage without spending any bucks !
+Find here the best publications about your favourite programming language without spending any bucks !
 
 Check it out : http://jsbooks.revolunet.com
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `language` rather than `langage`.

